### PR TITLE
Rudy/hot standby

### DIFF
--- a/tests/blackbox.py
+++ b/tests/blackbox.py
@@ -149,6 +149,10 @@ class NoopPgBackupStatements(object):
     def pg_version(cls):
         return {'version': 'FAKE-PG-VERSION'}
 
+    @classmethod
+    def pg_is_in_recovery(cls):
+        return False
+
 
 @pytest.fixture
 def noop_pg_backup_statements(monkeypatch):

--- a/wal_e/cmd.py
+++ b/wal_e/cmd.py
@@ -270,6 +270,14 @@ def build_parser():
         dest='while_offline',
         action='store_true',
         default=False)
+    backup_push_parser.add_argument(
+        '--hot-standby',
+        help=('Backup a Postgres cluster that is on standby '
+              'as if it was offline'
+              ),
+        dest='hot_standby',
+        action='store_true',
+        default=False)
 
     # wal-push operator section
     wal_push_parser = subparsers.add_parser(
@@ -556,7 +564,8 @@ def main():
                 args.PG_CLUSTER_DIRECTORY,
                 rate_limit=rate_limit,
                 while_offline=while_offline,
-                pool_size=args.pool_size)
+                pool_size=args.pool_size,
+                hot_standby=args.hot_standby)
         elif subcommand == 'wal-fetch':
             external_program_check([LZOP_BIN])
             res = backup_cxt.wal_restore(args.WAL_SEGMENT,

--- a/wal_e/operator/backup.py
+++ b/wal_e/operator/backup.py
@@ -177,7 +177,7 @@ class Backup(object):
                 start_backup_info = PgBackupStatements.run_start_backup()
                 version = PgBackupStatements.pg_version()['version']
             else:
-                postgres_pid = os.path.join(data_directory,'postmaster.pid')
+                postgres_pid = os.path.join(data_directory, 'postmaster.pid')
                 if while_offline and os.path.exists(postgres_pid):
                     hint = ('Shut down postgres.  '
                             'If there is a stale lockfile, '

--- a/wal_e/operator/backup.py
+++ b/wal_e/operator/backup.py
@@ -115,7 +115,7 @@ class Backup(object):
                 with open(restore_spec, 'r') as fs:
                     spec = json.load(fs)
                 backup_info.spec.update(spec)
-            if 'base_prefix' not in spec or not spec['base_prefix']:
+            if 'base_prefix' not in backup_info.spec or not backup_info.spec['base_prefix']:
                 backup_info.spec['base_prefix'] = pg_cluster_dir
             self._build_restore_paths(backup_info.spec)
         else:
@@ -451,6 +451,8 @@ class Backup(object):
 
         if not os.path.isdir(path_prefix):
             os.mkdir(path_prefix, DEFAULT_DIR_MODE)
+
+        if not os.path.isdir(tblspc_prefix):
             os.mkdir(tblspc_prefix, DEFAULT_DIR_MODE)
 
         for tblspc in restore_spec['tablespaces']:

--- a/wal_e/tar_partition.py
+++ b/wal_e/tar_partition.py
@@ -443,6 +443,11 @@ def partition(pg_cluster_dir):
     for root, dirnames, filenames in walker:
         is_cluster_toplevel = (os.path.abspath(root) ==
                                os.path.abspath(pg_cluster_dir))
+
+        # Append root so we will create the directory during restore even if
+        # PostgreSQL empties the directory before tar and upload completes
+        matches.append(root)
+
         # Do not capture any WAL files, although we do want to
         # capture the WAL directory or symlink
         if is_cluster_toplevel and 'pg_xlog' in dirnames:
@@ -470,10 +475,6 @@ def partition(pg_cluster_dir):
                 pass
             else:
                 matches.append(os.path.join(root, filename))
-
-        # Special case for empty directories
-        if not filenames:
-            matches.append(root)
 
         # Special case for tablespaces
         if root == os.path.join(pg_cluster_dir, 'pg_tblspc'):

--- a/wal_e/worker/pg/psql_worker.py
+++ b/wal_e/worker/pg/psql_worker.py
@@ -136,3 +136,12 @@ class PgBackupStatements(object):
 
         """
         return cls._dict_transform(psql_csv_run('SELECT * FROM version()'))
+
+    @classmethod
+    def pg_is_in_recovery(cls):
+        """
+        Return a boolean indicating whether Postgres is in Recovery
+        """
+        is_hot_standby = cls._dict_transform(psql_csv_run(
+                            'SELECT pg_is_in_recovery()'))
+        return is_hot_standby['pg_is_in_recovery']=='t'

--- a/wal_e/worker/pg/psql_worker.py
+++ b/wal_e/worker/pg/psql_worker.py
@@ -144,4 +144,4 @@ class PgBackupStatements(object):
         """
         is_hot_standby = cls._dict_transform(psql_csv_run(
                             'SELECT pg_is_in_recovery()'))
-        return is_hot_standby['pg_is_in_recovery']=='t'
+        return is_hot_standby['pg_is_in_recovery'] == 't'


### PR DESCRIPTION
@miketheman 
Managed to have it working.
On a replication-node, I can
- Do a wal-e backup-push --hot-standby
- rm the $PG_DATA folder
- Do a wal-e backup-fetch
- Add a recovery.conf file with a restore-command containing 'wal-e wal-fetch'
- start postgres

and it will come up and follow the master


This will only work if you do it on a real hot-standby instance. 
If the backup is done this way on a host that is running as a master (added a check to prevent it), you are not going to be able to restore cleanly.